### PR TITLE
OPSEXP-3292 Review usage of stefanzweifel/git-auto-commit-action and bump version to v6

### DIFF
--- a/.github/workflows/jekyll-publish.yml
+++ b/.github/workflows/jekyll-publish.yml
@@ -127,7 +127,7 @@ jobs:
           ls -la
 
       - name: Commit and push changes to ${{ inputs.publish-branch }} branch
-        uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842 # v5.0.1
+        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
         with:
           commit_message: "Update jekyll site"
           branch: ${{ inputs.publish-branch }}


### PR DESCRIPTION
### Related Issue
[OPSEXP-3292]

Review usage of **stefanzweifel/git-auto-commit-action** and bump version to v6
Please refer release notes [Release v6.0.0 · stefanzweifel/git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action/releases/tag/v6.0.0)
### Changes introduced
Updated stefanzweifel/git-auto-commit-action to [stefanzweifel/git-auto-commit-action@778341a](https://github.com/stefanzweifel/git-auto-commit-action/commit/778341af668090896ca464160c2def5d1d1a3eb0) (#v6.0.1) in below workflow

.github/workflows/jekyll-publish.yml